### PR TITLE
Fix for Lack of Rate Limiting in traduora

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -30,6 +30,7 @@
     "class-validator": "^0.10.0",
     "csv": "^5.1.1",
     "ejs": "^2.6.1",
+    "express-rate-limit": "^5.1.3",
     "generate-password": "^1.4.1",
     "gettext-parser": "^3.1.0",
     "handlebars": "^4.5.3",

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -5,6 +5,7 @@ import { PassportModule } from '@nestjs/passport';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { renderFile } from 'ejs';
+import * as rateLimit from 'express-rate-limit';
 import { config } from './config';
 import { AuthController } from './controllers/auth.controller';
 import { ExportsController } from './controllers/exports.controller';
@@ -98,6 +99,14 @@ export const addPipesAndFilters = (app: NestExpressApplication) => {
       transform: false,
       disableErrorMessages: true,
       whitelist: true,
+    }),
+  );
+  
+    // rate-limiting middleware
+  app.use(
+    rateLimit({
+      windowMs: 15 * 60 * 1000, // 15 minutes
+      max: 20, // limit each IP to 20 requests per windowMs
     }),
   );
 

--- a/api/src/services/user.service.ts
+++ b/api/src/services/user.service.ts
@@ -186,10 +186,6 @@ export class UserService {
       throw new UnauthorizedException('invalid credentials');
     }
 
-    const timeThreshold = moment()
-      .subtract(15, 'minutes')
-      .toDate();
-
     switch (grantType) {
       case GrantType.Password:
         if (!user.encryptedPassword) {

--- a/api/src/services/user.service.ts
+++ b/api/src/services/user.service.ts
@@ -190,14 +190,6 @@ export class UserService {
       .subtract(15, 'minutes')
       .toDate();
 
-    // If lockout time has passed, reset counter
-    if (user.lastLogin < timeThreshold) {
-      user.loginAttempts = 0;
-      // Otherwise abort request
-    } else if (user.loginAttempts >= 3) {
-      throw new TooManyRequestsException('too many login attempts');
-    }
-
     switch (grantType) {
       case GrantType.Password:
         if (!user.encryptedPassword) {


### PR DESCRIPTION
### :bar_chart: Metadata *

Traduora is a translation management platform for teams. Once you setup your project you can import and export your translations to various formats, work together with your team, instantly deliver translation updates over the air, and soon automatically translate your project via third-party integrations.

#### Bounty URL: https://www.huntr.dev/bounties/3-other-traduora

### :gear: Description *

Lack of Rate Limiting in the login page of traduora.

### :computer: Technical Description *

Traduora uses a weak algorithm to implement rate limiting, which only tried to protect against incoming requests issued to `/api/v1/auth/token`. This fix uses the [express-rate-limit](https://www.npmjs.com/package/express-rate-limit) package. I've implemented the rate limiter as a global middleware so all the `/api` endpoints are protected.

### :bug: Proof of Concept (PoC) *
* clone the github repo
* setted up traduora platform to reproduce the vulnerability
* I used an intruder in BURP SUITE to test for rate limiting on the password field.
* In normal intruder function it shows status code 429 that is ratelimit function is there
* To bypass it use intruder with throttle above 700 and use thread 100+ , for wrong password it shows 401 errror if right password comes it shows 200 error.

### Existing Protection
![poc_protection](https://raw.githubusercontent.com/arjunshibu/files/main/traduora-poc/protection.png)
### Bypass
![poc_bypass](https://raw.githubusercontent.com/arjunshibu/files/main/traduora-poc/bypass.png)

### :fire: Proof of Fix (PoF) *

After fix, all the API endpoints are protected with rate limiting. 

![pof_fix](https://raw.githubusercontent.com/arjunshibu/files/main/traduora-poc/fix.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.